### PR TITLE
Add runnable React budget app

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 // App.js
-import React, { useState, useEffect } from 'react';
-import './App.css';
+// React and ReactDOM are loaded via CDN in index.html
+const { useState, useEffect } = React;
 
 const BudgetTracker = () => {
   const [expenses, setExpenses] = useState([]);
@@ -427,4 +427,5 @@ const BudgetTracker = () => {
   );
 };
 
-export default BudgetTracker;
+// Render the application
+ReactDOM.render(<BudgetTracker />, document.getElementById('root'));

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Budget App
+
+This project is a simple budget tracking app built with React. All dependencies are loaded from CDN so no build step is required.
+
+## Running the App
+
+1. Open `index.html` in a modern web browser.
+2. The application will load and persist data using `localStorage`.
+
+## Features
+
+- Track expenses with categories and descriptions.
+- Set budgets per category and visualize spending progress.
+- Basic analytics for spending by category.
+- Export and clear stored data.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Budget App</title>
+  <link rel="stylesheet" href="App.css">
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="App.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- modify App.js to run directly in browser with CDN React
- add index.html to load scripts and mount component
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68470d08b2108320acd7397f9bd60f22